### PR TITLE
Add timeout error handling with refresh button

### DIFF
--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -3,6 +3,7 @@ import TimeoutError from './TimeoutError';
 
 interface Props {
   children: React.ReactNode;
+  error?: Error | null;
 }
 
 interface State {
@@ -13,7 +14,10 @@ interface State {
 class ErrorBoundary extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
-    this.state = { hasError: false, isTimeout: false };
+    this.state = {
+      hasError: Boolean(props.error),
+      isTimeout: props.error?.message.includes('timed out') || false,
+    };
   }
 
   static getDerivedStateFromError(error: Error): State {
@@ -23,9 +27,18 @@ class ErrorBoundary extends React.Component<Props, State> {
     };
   }
 
+  componentDidUpdate(prevProps: Props) {
+    if (this.props.error !== prevProps.error) {
+      this.setState({
+        hasError: Boolean(this.props.error),
+        isTimeout: this.props.error?.message.includes('timed out') || false,
+      });
+    }
+  }
+
   render() {
-    if (this.state.hasError) {
-      if (this.state.isTimeout) {
+    if (this.state.hasError || this.props.error) {
+      if (this.state.isTimeout || this.props.error?.message.includes('timed out')) {
         return <TimeoutError />;
       }
       return null;

--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import TimeoutError from './TimeoutError';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  isTimeout: boolean;
+}
+
+class ErrorBoundary extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, isTimeout: false };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return {
+      hasError: true,
+      isTimeout: error.message.includes('timed out'),
+    };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      if (this.state.isTimeout) {
+        return <TimeoutError />;
+      }
+      return null;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/components/TimeoutError.tsx
+++ b/components/TimeoutError.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { useRouter } from 'next/router';
+
+const TimeoutError: React.FC = () => {
+  const router = useRouter();
+
+  const handleRefresh = () => {
+    router.reload();
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center p-6">
+      <p className="text-red-600 font-medium mb-4">
+        error: request timed out, please refresh to try again
+      </p>
+      <button
+        className="rounded text-center bg-purple-700 w-28 h-12 text-white font-bold transition duration-500 ease-in-out hover:bg-purple-800"
+        onClick={handleRefresh}
+      >
+        refresh
+      </button>
+    </div>
+  );
+};
+
+export default TimeoutError;

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -4,6 +4,10 @@ import PWABoilerplate from '../components/PWABoilerplate';
 import ErrorBoundary from '../components/ErrorBoundary';
 
 function App({ Component, pageProps }) {
+  const error = pageProps.error instanceof Error ? pageProps.error : null;
+  const filteredProps = { ...pageProps };
+  delete filteredProps.error;
+
   return (
     <>
       <Head>
@@ -17,11 +21,25 @@ function App({ Component, pageProps }) {
         />
       </Head>
       <PWABoilerplate />
-      <ErrorBoundary>
-        <Component {...pageProps} />
+      <ErrorBoundary error={error}>
+        <Component {...filteredProps} />
       </ErrorBoundary>
     </>
   );
+}
+
+App.getInitialProps = async ({ Component, ctx }) => {
+  let pageProps = {};
+
+  try {
+    if (Component.getInitialProps) {
+      pageProps = await Component.getInitialProps(ctx);
+    }
+  } catch (error) {
+    pageProps.error = error;
+  }
+
+  return { pageProps };
 }
 
 export default App;

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,6 +1,7 @@
 import '../styles/globals.css';
 import Head from 'next/head';
 import PWABoilerplate from '../components/PWABoilerplate';
+import ErrorBoundary from '../components/ErrorBoundary';
 
 function App({ Component, pageProps }) {
   return (
@@ -16,7 +17,9 @@ function App({ Component, pageProps }) {
         />
       </Head>
       <PWABoilerplate />
-      <Component {...pageProps} />
+      <ErrorBoundary>
+        <Component {...pageProps} />
+      </ErrorBoundary>
     </>
   );
 }

--- a/pages/api/index.js
+++ b/pages/api/index.js
@@ -1,6 +1,7 @@
 import * as cheerio from 'cheerio';
 import endpoints from './endpoints';
 import qs from 'qs';
+import fetchWithTimeout from '../../utils/fetchWithTimeout';
 
 export default async function index(req, res) {
   const {
@@ -15,7 +16,7 @@ export default async function index(req, res) {
   const url = site
     ? `${endpoints.FROM}?${qs.stringify(params)}`
     : `${endpoints.NEWS}?${qs.stringify(params)}`;
-  const data = await fetch(url).then((r) => r.text());
+  const data = await fetchWithTimeout(url).then((r) => r.text());
 
   const $ = cheerio.load(data);
   const stories = $('tr.athing').toArray();

--- a/pages/api/item.js
+++ b/pages/api/item.js
@@ -1,6 +1,7 @@
 import * as cheerio from 'cheerio';
 import endpoints from './endpoints';
 import DOMPurify from 'isomorphic-dompurify';
+import fetchWithTimeout from '../../utils/fetchWithTimeout';
 
 const cleanContent = (content) => {
   if (!content) return;
@@ -19,7 +20,7 @@ export default async function item(req, res) {
     query: { id },
   } = req;
 
-  const data = await fetch(`${endpoints.COMMENTS}?id=${id}`).then((r) =>
+  const data = await fetchWithTimeout(`${endpoints.COMMENTS}?id=${id}`).then((r) =>
     r.text(),
   );
 

--- a/pages/from.js
+++ b/pages/from.js
@@ -2,6 +2,7 @@ import React from 'react';
 import get from 'lodash/get';
 import Page from '../components/Page';
 import News from '../components/News';
+import fetchWithTimeout from '../utils/fetchWithTimeout';
 
 function From({ data, cookies }) {
   return (
@@ -14,7 +15,7 @@ function From({ data, cookies }) {
 From.getInitialProps = async function (ctx) {
   if (ctx.req) {
     const { url } = ctx.req;
-    const data = await fetch(
+    const data = await fetchWithTimeout(
       `${process.env.HOST}/api/from?${url.split('?')[1]}`
     ).then((r) => r.json());
     return {
@@ -28,7 +29,7 @@ From.getInitialProps = async function (ctx) {
     const site = get(ctx, 'query.site');
     const next = get(ctx, 'query.next');
     const apiUrl = `/api/from?site=${site}${next ? `&next=${next}` : ''}`;
-    const data = await fetch(apiUrl).then((r) => r.json());
+    const data = await fetchWithTimeout(apiUrl).then((r) => r.json());
     const cookies = document.cookie.split('; ').reduce((prev, current) => {
       const [name, ...value] = current.split('=');
       prev[name] = value.join('=');

--- a/pages/item.js
+++ b/pages/item.js
@@ -1,6 +1,7 @@
 import getQueryParameter from '../utils/getQueryParameter';
 import Page from '../components/Page';
 import Comments from '../components/Comments';
+import fetchWithTimeout from '../utils/fetchWithTimeout';
 
 const Item = ({ data }) => {
   return (
@@ -14,7 +15,7 @@ Item.getInitialProps = async function (ctx) {
   if (ctx.req) {
     const { url } = ctx.req;
     const id = getQueryParameter(`${process.env.HOST}${url}`, 'id');
-    const data = await fetch(`${process.env.HOST}/api/item?id=${id}`).then(
+    const data = await fetchWithTimeout(`${process.env.HOST}/api/item?id=${id}`).then(
       (r) => r.json()
     );
     return {
@@ -22,7 +23,7 @@ Item.getInitialProps = async function (ctx) {
     };
   } else {
     const id = get(ctx, 'query.id', 1);
-    const data = await fetch(`/api/item?id=${id}`).then((r) => r.json());
+    const data = await fetchWithTimeout(`/api/item?id=${id}`).then((r) => r.json());
     return {
       data,
     };

--- a/pages/news.js
+++ b/pages/news.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Page from '../components/Page';
 import News from '../components/News';
 import get from 'lodash/get';
+import fetchWithTimeout from '../utils/fetchWithTimeout';
 
 function NewsPage({ data, cookies }) {
   return (
@@ -14,7 +15,7 @@ function NewsPage({ data, cookies }) {
 NewsPage.getInitialProps = async function (ctx) {
   if (ctx.req) {
     const { url } = ctx.req;
-    const data = await fetch(
+    const data = await fetchWithTimeout(
       `${process.env.HOST}/api/news?${url.split('?')[1]}`
     ).then((r) => r.json());
     return {
@@ -23,7 +24,7 @@ NewsPage.getInitialProps = async function (ctx) {
     };
   } else {
     const p = get(ctx, 'query.p', 1);
-    const data = await fetch(`/api/news?p=${p}`).then((r) => r.json());
+    const data = await fetchWithTimeout(`/api/news?p=${p}`).then((r) => r.json());
     const cookies = document.cookie.split('; ').reduce((prev, current) => {
       const [name, ...value] = current.split('=');
       prev[name] = value.join('=');

--- a/utils/fetchWithTimeout.js
+++ b/utils/fetchWithTimeout.js
@@ -1,0 +1,14 @@
+async function fetchWithTimeout(url, options = {}) {
+  try {
+    const response = await fetch(url, {
+      ...options,
+      signal: AbortSignal.timeout(7000),
+    });
+    return response;
+  } catch (error) {
+    if (error.name === 'TimeoutError') {
+      throw new Error('Request timed out after 7 seconds');
+    }
+    throw error;
+  }
+}

--- a/utils/fetchWithTimeout.js
+++ b/utils/fetchWithTimeout.js
@@ -1,12 +1,33 @@
 async function fetchWithTimeout(url, options = {}) {
+  const TIMEOUT_DURATION = 7000;
+
   try {
-    const response = await fetch(url, {
-      ...options,
-      signal: AbortSignal.timeout(7000),
-    });
-    return response;
+    // Check if we're in a browser environment where AbortSignal.timeout is available
+    if (typeof window !== 'undefined' && AbortSignal.timeout) {
+      const response = await fetch(url, {
+        ...options,
+        signal: AbortSignal.timeout(TIMEOUT_DURATION),
+      });
+      return response;
+    } else {
+      // Fallback for Node.js or environments without AbortSignal.timeout
+      const controller = new AbortController();
+      const id = setTimeout(() => controller.abort(), TIMEOUT_DURATION);
+
+      try {
+        const response = await fetch(url, {
+          ...options,
+          signal: controller.signal,
+        });
+        clearTimeout(id);
+        return response;
+      } catch (error) {
+        clearTimeout(id);
+        throw error;
+      }
+    }
   } catch (error) {
-    if (error.name === 'TimeoutError') {
+    if (error.name === 'TimeoutError' || error.name === 'AbortError') {
       throw new Error('Request timed out after 7 seconds');
     }
     throw error;

--- a/utils/fetchWithTimeout.js
+++ b/utils/fetchWithTimeout.js
@@ -12,3 +12,5 @@ async function fetchWithTimeout(url, options = {}) {
     throw error;
   }
 }
+
+export default fetchWithTimeout;


### PR DESCRIPTION
This PR adds timeout error handling to all fetch requests with a user-friendly error message and refresh button.

Changes:
- Add fetchWithTimeout utility using AbortSignal.timeout for 7-second timeouts
- Create TimeoutError component with refresh button matching NavButtons style
- Add ErrorBoundary component for error handling
- Update _app.js to use ErrorBoundary

The changes improve user experience by:
- Setting a consistent 7-second timeout for all API requests
- Showing a clear error message when requests time out
- Providing an easy way to refresh the page and try again
- Maintaining visual consistency with existing button styles