### PR TITLE
Add rate limiting middleware for crawler traffic

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const RATE_LIMIT_WINDOW_MS = 60 * 1000; // 1 minute
+const MAX_REQUESTS_PER_WINDOW = 10; // max requests per window for crawlers
+
+// Simple in-memory sliding window rate limiter (per edge instance)
+const requestLog: Map<string, number[]> = new Map();
+
+// Clean up old entries periodically to prevent memory leaks
+let lastCleanup = Date.now();
+const CLEANUP_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
+function cleanup() {
+  const now = Date.now();
+  if (now - lastCleanup < CLEANUP_INTERVAL_MS) return;
+  lastCleanup = now;
+
+  const cutoff = now - RATE_LIMIT_WINDOW_MS;
+  for (const [key, timestamps] of requestLog) {
+    const filtered = timestamps.filter((t) => t > cutoff);
+    if (filtered.length === 0) {
+      requestLog.delete(key);
+    } else {
+      requestLog.set(key, filtered);
+    }
+  }
+}
+
+function isRateLimited(key: string): boolean {
+  cleanup();
+
+  const now = Date.now();
+  const cutoff = now - RATE_LIMIT_WINDOW_MS;
+  const timestamps = (requestLog.get(key) || []).filter((t) => t > cutoff);
+
+  if (timestamps.length >= MAX_REQUESTS_PER_WINDOW) {
+    requestLog.set(key, timestamps);
+    return true;
+  }
+
+  timestamps.push(now);
+  requestLog.set(key, timestamps);
+  return false;
+}
+
+// User-agent patterns to rate limit
+const RATE_LIMITED_CRAWLERS = [
+  'meta-externalagent',
+  'facebookexternalhit',
+];
+
+export function middleware(request: NextRequest) {
+  const userAgent = request.headers.get('user-agent')?.toLowerCase() || '';
+
+  const isCrawler = RATE_LIMITED_CRAWLERS.some((crawler) =>
+    userAgent.includes(crawler),
+  );
+
+  if (isCrawler) {
+    const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+      request.headers.get('x-real-ip') ||
+      'unknown';
+    const key = `crawler:${ip}`;
+
+    if (isRateLimited(key)) {
+      return new NextResponse('Too Many Requests', {
+        status: 429,
+        headers: {
+          'Retry-After': '60',
+          'Content-Type': 'text/plain',
+        },
+      });
+    }
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: [
+    // Match all paths except static files and _next internals
+    '/((?!_next/static|_next/image|favicon.ico|images/|manifest.json|sw.js|workbox-.*\\.js).*)',
+  ],
+};

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
This PR adds a middleware layer to rate limit requests from specific web crawlers (Meta/Facebook), protecting the application from excessive crawling activity.

## Key Changes
- **New middleware.ts**: Implements a sliding window rate limiter that:
  - Tracks requests per IP address for identified crawlers
  - Limits crawlers to 10 requests per 60-second window
  - Returns 429 (Too Many Requests) responses when limits are exceeded
  - Includes automatic cleanup of stale entries to prevent memory leaks
  - Targets Meta's external agent and Facebook's external hit crawlers
  - Applies to all routes except static assets and Next.js internals

- **TypeScript configuration fix**: Updated `next-env.d.ts` to reference the correct routes type definition path (`.next/types/` instead of `.next/dev/types/`)

## Implementation Details
- Uses an in-memory Map-based sliding window algorithm per edge instance
- Extracts client IP from `x-forwarded-for` or `x-real-ip` headers for rate limit keying
- Cleanup runs every 5 minutes to remove expired request timestamps
- Middleware matcher excludes static files, images, and Next.js internals to minimize overhead